### PR TITLE
Improve the `ApiRequestOptions` type

### DIFF
--- a/generated/core/ApiRequestOptions.ts
+++ b/generated/core/ApiRequestOptions.ts
@@ -1,16 +1,25 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type ApiRequestOptions = {
-    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+type BaseApiRequestOptions = {
     readonly url: string;
     readonly path?: Record<string, any>;
     readonly cookies?: Record<string, any>;
     readonly headers?: Record<string, any>;
     readonly query?: Record<string, any>;
-    readonly formData?: Record<string, any>;
-    readonly body?: any;
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
 };
+
+type ApiRequestOptionsWithoutFormDataAndBody = BaseApiRequestOptions & {
+    readonly method: 'GET' | 'HEAD' | 'OPTIONS';
+};
+
+type ApiRequestOptionsWithFormDataAndBody = BaseApiRequestOptions & {
+    readonly method: 'PUT' | 'POST' | 'DELETE' | 'PATCH';
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+};
+
+export type ApiRequestOptions = ApiRequestOptionsWithoutFormDataAndBody | ApiRequestOptionsWithFormDataAndBody;


### PR DESCRIPTION
I noticed that the two options, `formData` and `body`, are present in the type even when the HTTP request method cannot include a body.  

So, I created a union type in TypeScript that removes `formData` and `body` from the type when the HTTP request method is `GET`,  `HEAD` or `OPTIONS`.