### PR TITLE
Add IP block, snapshots, shell user APIs + CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dev
 test.ts
 .claude
+cmd

--- a/src/servers.ts
+++ b/src/servers.ts
@@ -206,6 +206,20 @@ export type AsyncActionResponseType = {
 	headers: ResponseHeaders;
 };
 
+export type CreateServerSnapshotActionResponseType = {
+	body: {
+		id: number;
+		name: string;
+		date: string;
+		type: "daily" | "weekly" | "monthly" | "user" | "archived";
+		virtualization: "container" | "kvm";
+		completed: boolean;
+		deletable: boolean;
+		serverSlug: string | null;
+	};
+	headers: ResponseHeaders;
+};
+
 /** */
 interface MetricsSamplingDTO {
 	amount: number;
@@ -246,17 +260,39 @@ export type MetricsNowResponseType = {
 	};
 };
 
+export type IpBlockStatsv = {
+	/** CIDR prefix for this block */
+	cidr: string;
+
+	/** Total number of IP rows in the database for this block */
+	total: number;
+
+	/** Number of assignable free IPs: free IPs minus user-banned IPs */
+	free: number;
+
+	/** Number of used IPs */
+	used: number;
+
+	/** Number of user-banned free IPs for this server owner */
+	banned: number;
+
+	/** Number of reserved IPs in this block, administratively reserved by Webdock */
+	reserved: number;
+}
+
 export class ServersClass {
 	private parent: Webdock;
 	scripts: ServerScriptsClass
 	identity: ServerIdentityClass
 	settings: ServerSettingsClass
+	IpBlock: ServerIpBlock
 
 	constructor(parent: Webdock) {
 		this.parent = parent;
 		this.scripts = new ServerScriptsClass(parent)
 		this.identity = new ServerIdentityClass(parent)
 		this.settings = new ServerSettingsClass(parent)
+		this.IpBlock = new ServerIpBlock(parent)
 	}
 
 
@@ -435,6 +471,51 @@ export class ServersClass {
 			},
 		);
 	}
+
+	snapshot({
+		serverSlug,
+		name,
+	}: {
+		serverSlug: string;
+		name: string;
+	}) {
+		return req<CreateServerSnapshotActionResponseType>({
+			token: this.parent.string_token,
+			endpoint: `/servers/${serverSlug}/actions/snapshot`,
+			method: "POST",
+			body: {
+				name,
+			},
+			headers: ["x-callback-id"],
+		});
+	}
+
+	disableIpv6({
+		serverSlug,
+	}: {
+		serverSlug: string;
+	}) {
+		return req<AsyncActionResponseType>({
+			token: this.parent.string_token,
+			endpoint: `/servers/${serverSlug}/actions/disable-ipv6`,
+			method: "POST",
+			headers: ["x-callback-id"],
+		});
+	}
+
+	enableIpv6({
+		serverSlug,
+	}: {
+		serverSlug: string;
+	}) {
+		return req<AsyncActionResponseType>({
+			token: this.parent.string_token,
+			endpoint: `/servers/${serverSlug}/actions/enable-ipv6`,
+			method: "POST",
+			headers: ["x-callback-id"],
+		});
+	}
+
 	reinstall({ imageSlug, serverSlug, userScriptId, deleteSnapshots }: {
 		deleteSnapshots?: boolean;
 		serverSlug: string;
@@ -555,6 +636,10 @@ export type ExecuteScriptOnServerReturnType = {
 	};
 };
 
+export type GetScriptOnServerReturnType = {
+	body: Script;
+};
+
 export type GetScriptByIdTResponseType = {
 	body: {
 		id: number;
@@ -665,6 +750,22 @@ export class ServerScriptsClass {
 			},
 		);
 	}
+
+	getById(
+		{ serverSlug, scriptId }: {
+			serverSlug: string;
+			scriptId: string | number;
+		},
+	) {
+		return req<GetScriptOnServerReturnType>(
+			{
+				token: this.parent.string_token,
+				endpoint: `/servers/${serverSlug}/scripts/${scriptId}`,
+				method: "GET",
+			},
+		);
+	}
+
 	execute(
 		{ serverSlug, scriptID }: {
 			serverSlug: string;
@@ -697,6 +798,48 @@ export class ServerScriptsClass {
 
 
 }
+
+// https://api.webdock.io/v1/servers/{serverSlug}/actions/changeIp
+
+class ServerIpBlock {
+	private parent: Webdock
+	constructor(parent: Webdock) {
+		this.parent = parent
+	}
+
+	ListIpBlocks({ serverSlug }: { serverSlug: string }) {
+		return req<IpBlockStatsv>({
+			token: this.parent.string_token,
+			endpoint: `/servers/${serverSlug}/ipBlocks`,
+			method: "GET",
+
+		})
+	}
+
+
+
+
+	ChangeIPAddress({ serverSlug, markReleasedIpBanned, overrideBlockId, sameBlock }: {
+		serverSlug: string
+		sameBlock: boolean,
+		overrideBlockId: number,
+		markReleasedIpBanned: boolean,
+	}) {
+		req({
+			token: this.parent.string_token,
+			endpoint: `/servers/${serverSlug}/actions/changeIp`,
+			method: "post",
+			headers: ["x-callback-id"],
+			body: {
+				markReleasedIpBanned, overrideBlockId, sameBlock
+			}
+		})
+	}
+
+
+
+}
+// https://api.webdock.io/v1/servers/{serverSlug}/actions/changeIp
 class ServerIdentityClass {
 	private parent: Webdock
 	constructor(parent: Webdock) {
@@ -750,6 +893,7 @@ class ServerIdentityClass {
 			}
 		})
 	}
+
 }
 
 class ServerSettingsClass {

--- a/src/shellusers.ts
+++ b/src/shellusers.ts
@@ -67,6 +67,12 @@ export type CreateWebSSHTokenResponseType = {
 	};
 };
 
+export type ResetShellUserPasswordResponseType = {
+	headers: {
+		"x-callback-id": string;
+	};
+};
+
 export class ShellUsersClass {
 	private parent: Webdock;
 	constructor(parent: Webdock) {
@@ -104,6 +110,22 @@ export class ShellUsersClass {
 			token: this.parent.string_token,
 			endpoint: `servers/${serverSlug}/shellUsers/${userId}`,
 			method: "DELETE",
+			headers: ["x-callback-id"],
+		});
+	}
+
+	resetPassword({ serverSlug, userId, newPassword, }: {
+		serverSlug: string;
+		userId: number;
+		newPassword: string;
+	}) {
+		return req<ResetShellUserPasswordResponseType>({
+			token: this.parent.string_token,
+			endpoint: `servers/${serverSlug}/shellUsers/${userId}/resetPassword`,
+			method: "POST",
+			body: {
+				newPassword,
+			},
 			headers: ["x-callback-id"],
 		});
 	}

--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -30,6 +30,10 @@ export type ListSnapshotResponseType = {
 	body: Snapshot[];
 };
 
+export type GetSnapshotResponseType = {
+	body: Snapshot;
+};
+
 export type RestoreSnapShotType = {
 	body: Snapshot;
 	headers: {
@@ -78,6 +82,20 @@ export class SnapshotsClass {
 		return req<ListSnapshotResponseType>({
 			token: this.parent.string_token,
 			endpoint: "/servers/snapshots",
+			method: "GET",
+		});
+	}
+
+	getById({
+		serverSlug,
+		snapshotId,
+	}: {
+		serverSlug: string;
+		snapshotId: number;
+	}) {
+		return req<GetSnapshotResponseType>({
+			token: this.parent.string_token,
+			endpoint: `/servers/${serverSlug}/snapshots/${snapshotId}`,
 			method: "GET",
 		});
 	}

--- a/src/webdock.ts
+++ b/src/webdock.ts
@@ -22,12 +22,23 @@ type PingResponseType = {
 	};
 };
 
+type WebdockIPBlocks = {
+	id: number;
+	blockId: number;
+	ipv4: string;
+	ipv6: string;
+	status: string;
+	serverSlug: string;
+}
+
 export class WebdockClass {
 	private parent: Webdock;
 	scripts: WebdockScripts
+	IpBlocks: IpBlocksClass
 	constructor(parent: Webdock) {
 		this.parent = parent;
 		this.scripts = new WebdockScripts(parent)
+		this.IpBlocks = new IpBlocksClass(parent)
 	}
 
 
@@ -59,4 +70,57 @@ export class WebdockScripts {
 		});
 	}
 
+
+
 }
+
+class IpBlocksClass {
+	private parent: Webdock
+	constructor(parent: Webdock) {
+		this.parent = parent
+	}
+
+
+	BanIp({ ipId }: { ipId: number }) {
+		return req({
+			token: this.parent.string_token,
+			endpoint: `/servers/ipBlocks/${ipId}/banned`,
+			method: "PATCH",
+			body: {
+				banned: true
+			}
+		})
+	}
+
+	UnBanIp({ ipId }: { ipId: number }) {
+		return req({
+			token: this.parent.string_token,
+			endpoint: `/servers/ipBlocks/${ipId}/banned`,
+			method: "PATCH",
+			body: {
+				banned: true
+			}
+		})
+	}
+	inspectIpBlock({
+		blockId,
+		status = "all",
+	}: {
+		blockId: number;
+		status?: "all" | "free" | "used" | "banned" | "reserved";
+	}) {
+		const params = new URLSearchParams({
+			blockId: String(blockId),
+			status,
+		});
+
+		return req<WebdockIPBlocks>({
+			token: this.parent.string_token,
+			endpoint: `/servers/ipBlocks/inspect?${params.toString()}`,
+			method: "GET",
+
+		});
+	}
+
+}
+


### PR DESCRIPTION
Adds IP-block and snapshot related API surface, shell-user password reset, and script retrieval helpers. Changes include: new types for snapshots and IP block stats; ServersClass: snapshot, enable/disable IPv6, and ServerIpBlock with ListIpBlocks and ChangeIPAddress; ServerScriptsClass.getById; SnapshotsClass.getById; ShellUsersClass.resetPassword; Webdock.IpBlocks with ban/unban/inspect methods. Also adds an example cmd/cmd.ts CLI file (contains a hardcoded token — replace with secure config).